### PR TITLE
Add and updated commands in travis config to fix failing cron jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,6 @@ deploy:
     on:
       repo: gcivil-nyu-org/team4-wed-spring25
       branch: main
+      condition: "$TRAVIS_EVENT_TYPE = push"
     
 skip_cleanup: 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ after_success:
   - coverage report
   - coveralls --service=travis-pro
 
+
+before_install:
+  - gem update --system
+  - gem install bundler
+
 deploy:
   - provider: elasticbeanstalk
     bucket_name: elasticbeanstalk-us-east-1-783764589295

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ deploy:
       repo: gcivil-nyu-org/team4-wed-spring25
       branch: develop
 
-  - provider: elasticbeanstalk
+  - if: type != cron
+    provider: elasticbeanstalk
     bucket_name: elasticbeanstalk-us-west-2-940482403872
     region: us-west-2
     bucket_path: pawpark-prod
@@ -56,6 +57,5 @@ deploy:
     on:
       repo: gcivil-nyu-org/team4-wed-spring25
       branch: main
-      condition: "$TRAVIS_EVENT_TYPE = push"
     
 skip_cleanup: 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ python:
 services:
   - postgresql
 
+before_install:
+  - gem update --system
+  - gem install bundler
+
 install:
   - pip install -r requirements.txt
 
@@ -27,11 +31,6 @@ after_success:
   - coverage report
   - coveralls --service=travis-pro
 
-
-before_install:
-  - gem update --system
-  - gem install bundler
-
 deploy:
   - provider: elasticbeanstalk
     bucket_name: elasticbeanstalk-us-east-1-783764589295
@@ -44,9 +43,9 @@ deploy:
     on:
       repo: gcivil-nyu-org/team4-wed-spring25
       branch: develop
+    skip_cleanup: 'true'
 
-  - if: type != cron
-    provider: elasticbeanstalk
+  - provider: elasticbeanstalk
     bucket_name: elasticbeanstalk-us-west-2-940482403872
     region: us-west-2
     bucket_path: pawpark-prod
@@ -57,5 +56,6 @@ deploy:
     on:
       repo: gcivil-nyu-org/team4-wed-spring25
       branch: main
-    
-skip_cleanup: 'true'
+      condition: $TRAVIS_EVENT_TYPE != cron
+    skip_cleanup: 'true'  
+


### PR DESCRIPTION
Added before_install commands to update Travis' RubyGem envs in cron jobs to prevent version mismatch leading to failing jobs

Also added command to skip deployment and only run tests in a cron job